### PR TITLE
Fixing build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.idea
+.gitignore

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(int_abs_diff)]
 use core::convert::{From};
 use core::time::Duration;
 

--- a/src/shaders/pallete_shader/shader.rs
+++ b/src/shaders/pallete_shader/shader.rs
@@ -66,7 +66,7 @@ impl PalleteSpriteShaderPass {
         PalleteSpriteShaderPass {
             uniform: Uniform::new(ctx, PalleteSpriteUniform::new(ortho, pallete)),
             atlas: ctx.default_texture(),
-            scanline: Texture::from_png(ctx, include_bytes!("../.../../../../resources/scanline_5.png"), TextureFiltering::none()),
+            scanline: Texture::from_png(ctx, include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"),  "/resources/scanline_5.png")), TextureFiltering::none()),
             buffer: Buffer::new(ctx),
             pallete
         }

--- a/src/shaders/sprite/shader.rs
+++ b/src/shaders/sprite/shader.rs
@@ -63,7 +63,7 @@ impl SpriteShaderPass {
         SpriteShaderPass {
             uniform: Uniform::new(ctx, SpriteUniform::new(ortho)),
             atlas: ctx.default_texture(),
-            scanline: Texture::from_png(ctx, include_bytes!("../.../../../../resources/scanline_5.png"), TextureFiltering::none()),
+            scanline: Texture::from_png(ctx, include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"),  "/resources/scanline_5.png")), TextureFiltering::none()),
             buffer: Buffer::new(ctx),
         }
     }


### PR DESCRIPTION
int_abs_diff stable since Rust 1.6 (unless we're sticking to an older version?) 
paths updated to use project root